### PR TITLE
Fix crash on unknown option

### DIFF
--- a/mapper.cpp
+++ b/mapper.cpp
@@ -82,6 +82,7 @@ int main(int argc, char *argv[])
 		{"max-y", required_argument, 0, 'c'},
 		{"zoom", required_argument, 0, 'z'},
 		{"colors", required_argument, 0, 'C'},
+		{0, 0, 0, 0}
 	};
 
 	std::string input;


### PR DESCRIPTION
getopts requires the last element of longopts to be filled with zeros.
Fixes possible segfault in case of unknown long option