### PR TITLE
DBRedis: use HMGET instead of HGET

### DIFF
--- a/db-redis.cpp
+++ b/db-redis.cpp
@@ -71,6 +71,26 @@ std::vector<BlockPos> DBRedis::getBlockPos()
 }
 
 
+std::string DBRedis::replyTypeStr(int type) {
+	switch(type) {
+		case REDIS_REPLY_STATUS:
+			return "REDIS_REPLY_STATUS";
+		case REDIS_REPLY_ERROR:
+			return "REDIS_REPLY_ERROR";
+		case REDIS_REPLY_INTEGER:
+			return "REDIS_REPLY_INTEGER";
+		case REDIS_REPLY_NIL:
+			return "REDIS_REPLY_NIL";
+		case REDIS_REPLY_STRING:
+			return "REDIS_REPLY_STRING";
+		case REDIS_REPLY_ARRAY:
+			return "REDIS_REPLY_ARRAY";
+		default:
+			return "UNKNOWN_REPLY_TYPE";
+	}
+}
+
+
 void DBRedis::loadPosCache()
 {
 	redisReply *reply;

--- a/db-redis.h
+++ b/db-redis.h
@@ -11,6 +11,8 @@ public:
 	virtual void getBlocksOnZ(std::map<int16_t, BlockList> &blocks, int16_t zPos);
 	virtual ~DBRedis();
 private:
+	static std::string replyTypeStr(int type);
+
 	void loadPosCache();
 
 	std::vector<BlockPos> posCache;

--- a/db-redis.h
+++ b/db-redis.h
@@ -14,6 +14,7 @@ private:
 	static std::string replyTypeStr(int type);
 
 	void loadPosCache();
+	void HMGET(const std::vector<BlockPos> &positions, std::vector<ustring> *result);
 
 	std::vector<BlockPos> posCache;
 


### PR DESCRIPTION
Redis HMGET request allows querying multiple fields at the same time, reducing time spent in round trip on network, as well as system resource usage when Redis server is local.

Use it with a maximum of DB_REDIS_HMGET_NUMKEYS fields per request. Its value (30) was chosen to keep most responses in a single IP packet when running on the same machine as Redis server. It should not be set too high since Redis is single threaded and players could suffer latency problems.