### PR TITLE
TileGenerator: free database resources

### DIFF
--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -110,7 +110,8 @@ TileGenerator::TileGenerator():
 	m_shading(true),
 	m_backend(""),
 	m_border(0),
-	m_image(0),
+	m_db(NULL),
+	m_image(NULL),
 	m_xMin(INT_MAX),
 	m_xMax(INT_MIN),
 	m_zMin(INT_MAX),
@@ -127,6 +128,7 @@ TileGenerator::TileGenerator():
 
 TileGenerator::~TileGenerator()
 {
+	closeDatabase();
 }
 
 void TileGenerator::setBgColor(const std::string &bgColor)
@@ -246,6 +248,7 @@ void TileGenerator::generate(const std::string &input, const std::string &output
 	loadBlocks();
 	createImage();
 	renderMap();
+	closeDatabase();
 	if (m_drawScale) {
 		renderScale();
 	}
@@ -312,6 +315,12 @@ void TileGenerator::openDb(const std::string &input)
 #endif
 	else
 		throw std::runtime_error(((std::string) "Unknown map backend: ") + backend);
+}
+
+void TileGenerator::closeDatabase()
+{
+	delete m_db;
+	m_db = NULL;
 }
 
 void TileGenerator::loadBlocks()

--- a/TileGenerator.h
+++ b/TileGenerator.h
@@ -76,6 +76,7 @@ public:
 private:
 	void parseColorsStream(std::istream &in);
 	void openDb(const std::string &input);
+	void closeDatabase();
 	void loadBlocks();
 	void createImage();
 	void renderMap();

--- a/db-leveldb.h
+++ b/db-leveldb.h
@@ -9,7 +9,7 @@ public:
 	DBLevelDB(const std::string &mapdir);
 	virtual std::vector<BlockPos> getBlockPos();
 	virtual void getBlocksOnZ(std::map<int16_t, BlockList> &blocks, int16_t zPos);
-	~DBLevelDB();
+	virtual ~DBLevelDB();
 private:
 	void loadPosCache();
 

--- a/db-redis.h
+++ b/db-redis.h
@@ -9,7 +9,7 @@ public:
 	DBRedis(const std::string &mapdir);
 	virtual std::vector<BlockPos> getBlockPos();
 	virtual void getBlocksOnZ(std::map<int16_t, BlockList> &blocks, int16_t zPos);
-	~DBRedis();
+	virtual ~DBRedis();
 private:
 	void loadPosCache();
 

--- a/db-sqlite3.h
+++ b/db-sqlite3.h
@@ -9,7 +9,7 @@ public:
 	DBSQLite3(const std::string &mapdir);
 	virtual std::vector<BlockPos> getBlockPos();
 	virtual void getBlocksOnZ(std::map<int16_t, BlockList> &blocks, int16_t zPos);
-	~DBSQLite3();
+	virtual ~DBSQLite3();
 private:
 	sqlite3 *db;
 

--- a/db.h
+++ b/db.h
@@ -55,6 +55,7 @@ protected:
 public:
 	virtual std::vector<BlockPos> getBlockPos() = 0;
 	virtual void getBlocksOnZ(std::map<int16_t, BlockList> &blocks, int16_t zPos) = 0;
+	virtual ~DB() {};
 };
 
 


### PR DESCRIPTION
Destructor of DB* instance was never called.
Ensure it is, adding missing base class virtual destructor and calling
delete when possible to free resources.