### PR TITLE
Add flag to get the extent of the generated map 

### DIFF
--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -348,8 +348,19 @@ void TileGenerator::createImage()
 	if(!m_drawScale)
 		m_scales = 0;
 
+	int gw = (m_geomX2 - m_geomX) * 16;
+	int gh = (m_geomY2 - m_geomY) * 16;
+
+
 	m_mapWidth = (m_xMax - m_xMin + 1) * 16;
 	m_mapHeight = (m_zMax - m_zMin + 1) * 16;
+
+	if (m_geomX > -2048 && m_geomX2 < 2048)
+		m_mapWidth = m_mapWidth > gw ? m_mapWidth : gw;
+
+	if (m_geomY > -2048 && m_geomY2 < 2048)
+		m_mapHeight = m_mapHeight > gh ? m_mapWidth : gh;
+
 	m_xBorder = (m_scales & SCALE_LEFT) ? scale_d : 0;
 	m_yBorder = (m_scales & SCALE_TOP) ? scale_d : 0;
 	m_blockPixelAttributes.setWidth(m_mapWidth);

--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -208,6 +208,23 @@ void TileGenerator::parseColorsFile(const std::string &fileName)
 	parseColorsStream(in);
 }
 
+void TileGenerator::printGeometry(const std::string &input)
+{
+	string input_path = input;
+	if (input_path[input.length() - 1] != PATH_SEPARATOR) {
+		input_path += PATH_SEPARATOR;
+	}
+
+	openDb(input_path);
+	loadBlocks();
+
+	printf("\nMap extent: %d:%d+%d+%d\n", m_xMin*16, m_zMin*16, (m_xMax - m_xMin+1)*16, (m_zMax - m_zMin+1)*16);
+
+	closeDatabase();
+
+}
+
+
 void TileGenerator::generate(const std::string &input, const std::string &output)
 {
 	string input_path = input;

--- a/include/TileGenerator.h
+++ b/include/TileGenerator.h
@@ -86,6 +86,7 @@ public:
 	void parseColorsFile(const std::string &fileName);
 	void setBackend(std::string backend);
 	void generate(const std::string &input, const std::string &output);
+	void printGeometry(const std::string &input);
 	void setZoom(int zoom);
 	void setScales(uint flags);
 

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -28,6 +28,7 @@ void usage()
 			"  --max-y <y>\n"
 			"  --backend <backend>\n"
 			"  --geometry x:y+w+h\n"
+			"  --extent\n"
 			"  --zoom <zoomlevel>\n"
 			"  --colors <colors.txt>\n"
 			"  --scales [t][b][l][r]\n"
@@ -80,6 +81,7 @@ int main(int argc, char *argv[])
 		{"noshading", no_argument, 0, 'H'},
 		{"backend", required_argument, 0, 'd'},
 		{"geometry", required_argument, 0, 'g'},
+		{"extent", no_argument, 0, 'E'},
 		{"min-y", required_argument, 0, 'a'},
 		{"max-y", required_argument, 0, 'c'},
 		{"zoom", required_argument, 0, 'z'},
@@ -95,6 +97,7 @@ int main(int argc, char *argv[])
 	TileGenerator generator;
 	int option_index = 0;
 	int c = 0;
+	bool onlyPrintExtent = false;
 	while (1) {
 		c = getopt_long(argc, argv, "hi:o:", long_options, &option_index);
 		if (c == -1) {
@@ -138,6 +141,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'e':
 				generator.setDrawAlpha(true);
+				break;
+			case 'E':
+				onlyPrintExtent = true;
 				break;
 			case 'H':
 				generator.setShading(false);
@@ -206,7 +212,14 @@ int main(int argc, char *argv[])
 		colors = search_colors(input);
 	try {
 		generator.parseColorsFile(colors);
-		generator.generate(input, output);
+		if (onlyPrintExtent)
+		{
+			generator.printGeometry(input);
+		}
+		else
+		{
+			generator.generate(input, output);
+		}
 	} catch(std::runtime_error e) {
 		std::cerr << "Exception: " << e.what() << std::endl;
 		return 1;

--- a/minetestmapper.6
+++ b/minetestmapper.6
@@ -73,6 +73,10 @@ Use specific map backend; supported: *sqlite3*, *leveldb*, *redis*, *postgresql*
 Limit area to specific geometry (*x:y+w+h* where x and y specify the lower left corner), e.g. "--geometry -800:-800+1600+1600"
 
 .TP
+.BR \-\-extent " " \fIextent\fR
+Dont render the image, dust print the extent of the map that would be generated, in the same format as the geometry above.
+
+.TP
 .BR \-\-zoom " " \fIfactor\fR
 Zoom the image by using more than one pixel per node, e.g. "--zoom 4"
 


### PR DESCRIPTION
without actually rendering the image.

I needed to get the extents, to then generate tiles in a loop using the -geometry option.

Rendering the whole map in one go is too much for my server.