### PR TITLE
Create images exactly the requested size and don't output empty images.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,9 @@ extent:
 noshading:
     Don't draw shading on nodes, ``--noshading``
 
+noemptyimage:
+    Don't output anything when the image would be empty, ``--noemptyimage``
+
 min-y:
     Don't draw nodes below this y value, e.g. ``--min-y -25``
 

--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -352,8 +352,25 @@ void TileGenerator::createImage()
 	if(!m_drawScale)
 		m_scales = 0;
 
+
+	// If a geometry is explicitly set, set the bounding box to the requested geometry
+	// instead of cropping to the content. This way we will always output a full tile
+	// of the correct size.
+	if (m_geomX > -2048 && m_geomX2 < 2048)
+	{
+		m_xMin = m_geomX;
+		m_xMax = m_geomX2-1;
+	}
+
+	if (m_geomY > -2048 && m_geomY2 < 2048)
+	{
+		m_zMin = m_geomY;
+		m_zMax = m_geomY2-1;
+	}
+
 	m_mapWidth = (m_xMax - m_xMin + 1) * 16;
 	m_mapHeight = (m_zMax - m_zMin + 1) * 16;
+
 	m_xBorder = (m_scales & SCALE_LEFT) ? scale_d : 0;
 	m_yBorder = (m_scales & SCALE_TOP) ? scale_d : 0;
 	m_blockPixelAttributes.setWidth(m_mapWidth);

--- a/TileGenerator.cpp
+++ b/TileGenerator.cpp
@@ -79,6 +79,7 @@ TileGenerator::TileGenerator():
 	m_drawScale(false),
 	m_drawAlpha(false),
 	m_shading(true),
+	m_dontWriteEmpty(false),
 	m_backend(""),
 	m_xBorder(0),
 	m_yBorder(0),
@@ -228,6 +229,10 @@ void TileGenerator::printGeometry(const std::string &input)
 
 }
 
+void TileGenerator::setDontWriteEmpty(bool f)
+{
+	m_dontWriteEmpty = f;
+}
 
 void TileGenerator::generate(const std::string &input, const std::string &output)
 {
@@ -238,6 +243,13 @@ void TileGenerator::generate(const std::string &input, const std::string &output
 
 	openDb(input_path);
 	loadBlocks();
+
+	if (m_dontWriteEmpty  && ! m_positions.size())
+	{
+		closeDatabase();
+		return;
+	}
+
 	createImage();
 	renderMap();
 	closeDatabase();

--- a/include/TileGenerator.h
+++ b/include/TileGenerator.h
@@ -89,6 +89,7 @@ public:
 	void printGeometry(const std::string &input);
 	void setZoom(int zoom);
 	void setScales(uint flags);
+	void setDontWriteEmpty(bool f);
 
 private:
 	void parseColorsStream(std::istream &in);
@@ -120,6 +121,7 @@ private:
 	bool m_drawScale;
 	bool m_drawAlpha;
 	bool m_shading;
+	bool m_dontWriteEmpty;
 	std::string m_backend;
 	int m_xBorder, m_yBorder;
 

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -24,6 +24,7 @@ void usage()
 			"  --draworigin\n"
 			"  --drawalpha\n"
 			"  --noshading\n"
+			"  --noemptyimage\n"
 			"  --min-y <y>\n"
 			"  --max-y <y>\n"
 			"  --backend <backend>\n"
@@ -87,6 +88,7 @@ int main(int argc, char *argv[])
 		{"zoom", required_argument, 0, 'z'},
 		{"colors", required_argument, 0, 'C'},
 		{"scales", required_argument, 0, 'f'},
+		{"noemptyimage", no_argument, 0, 'n'},
 		{0, 0, 0, 0}
 	};
 
@@ -194,6 +196,9 @@ int main(int argc, char *argv[])
 				break;
 			case 'C':
 				colors = optarg;
+				break;
+			case 'n':
+				generator.setDontWriteEmpty(true);
 				break;
 			default:
 				exit(1);

--- a/minetestmapper.6
+++ b/minetestmapper.6
@@ -57,6 +57,10 @@ Allow nodes to be drawn with transparency
 Don't draw shading on nodes
 
 .TP
+.BR \-\-noemptyimage
+Don't output anything when the image would be empty.
+
+.TP
 .BR \-\-min-y " " \fInumber\fR
 Don't draw nodes below this y value, e.g. "--min-y -25"
 


### PR DESCRIPTION
I'm generating tiles for a slippy map and all tiles should have the same size, so when requesting a specific geometry, don't crop the output to the content.

Also, empty tiles are useless and only generate bandwidth on your server without actually displaying anything, so I'd like to suppress them.