### PR TITLE
Add Dockerfile and workflow to publish image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+
+*~
+
+minetestmapper
+minetestmapper.exe
+
+CMakeCache.txt
+CMakeFiles/
+CPack*.cmake
+_CPack_Packages/
+install_manifest.txt
+Makefile
+cmake_install.cmake
+cmake_config.h

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,87 @@
+---
+name: docker_image
+
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+# https://docs.docker.com/build/ci/github-actions/multi-platform
+# https://github.com/opencontainers/image-spec/blob/main/annotations.md
+
+on:
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ "*" ]
+  pull_request:
+    # Build docker image on pull requests. (but do not publish)
+    paths:
+      - '**/**.[ch]'
+      - '**/**.cpp'
+  workflow_dispatch:
+    inputs:
+      use_cache:
+        description: "Use build cache"
+        required: true
+        type: boolean
+        default: true
+
+env:
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
+      # Login against the Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5.5.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.title=Minetest Mapper
+            org.opencontainers.image.vendor=Minetest
+            org.opencontainers.image.licenses=BSD 2-Clause
+
+      # Build and push Docker image
+      # https://github.com/docker/build-push-action
+      # No arm support for now. Require cross-compilation support in Dockerfile to not use QEMU.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5.1.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          no-cache: ${{ (github.event_name == 'workflow_dispatch' && !inputs.use_cache) || startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Test Docker Image
+        run: |
+          docker run --rm $(cut -d, -f1 <<<"$DOCKER_METADATA_OUTPUT_TAGS") minetestserver --version
+        shell: bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
 ARG DOCKER_IMAGE=alpine:3.19
-FROM $DOCKER_IMAGE AS dev
+FROM $DOCKER_IMAGE AS builder
 
 RUN apk add --no-cache build-base cmake \
 		gd-dev sqlite-dev postgresql-dev hiredis-dev leveldb-dev \
-		ninja ca-certificates
-
-FROM dev as builder
+		ninja
 
 COPY . /usr/src/minetestmapper
 WORKDIR /usr/src/minetestmapper
 
-RUN cmake -B build && \
+RUN cmake -B build -G Ninja && \
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
@@ -23,5 +21,6 @@ RUN apk add --no-cache libstdc++ libgcc libpq \
 
 COPY --from=builder /usr/local/share/minetest /usr/local/share/minetest
 COPY --from=builder /usr/local/bin/minetestmapper /usr/local/bin/minetestmapper
+COPY COPYING /usr/local/share/minetest/minetestmapper.COPYING
 
 ENTRYPOINT ["/usr/local/bin/minetestmapper"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+ARG DOCKER_IMAGE=alpine:3.19
+FROM $DOCKER_IMAGE AS dev
+
+RUN apk add --no-cache build-base cmake \
+		gd-dev sqlite-dev postgresql-dev hiredis-dev leveldb-dev \
+		ninja ca-certificates
+
+FROM dev as builder
+
+COPY . /usr/src/minetestmapper
+WORKDIR /usr/src/minetestmapper
+
+RUN cmake -B build && \
+    cmake --build build --parallel $(nproc) && \
+    cmake --install build
+
+RUN ls /usr/local/share/minetest
+
+FROM $DOCKER_IMAGE AS runtime
+
+RUN apk add --no-cache libstdc++ libgcc libpq \
+        gd sqlite-libs postgresql hiredis leveldb
+
+COPY --from=builder /usr/local/share/minetest /usr/local/share/minetest
+COPY --from=builder /usr/local/bin/minetestmapper /usr/local/bin/minetestmapper
+
+ENTRYPOINT ["/usr/local/bin/minetestmapper"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN cmake -B build -G Ninja && \
     cmake --build build --parallel $(nproc) && \
     cmake --install build
 
-RUN ls /usr/local/share/minetest
-
 FROM $DOCKER_IMAGE AS runtime
 
 RUN apk add --no-cache libstdc++ libgcc libpq \


### PR DESCRIPTION
This PR adds a `Dockerfile` which compiles `minetestmapper` and puts it into a Docker image. Additionally, a workflow file is added to publish the images to `ghcr.io/minetest/minetestmapper` on `master` change.

This PR is ready for review.